### PR TITLE
fix: resolve PostgreSQL entity extraction issues

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -896,7 +896,9 @@ class PGGraphStorage(BaseGraphStorage):
                             vertices.get(edge["end_id"], {}),
                         )
             else:
-                if v is None or (v.count("{") < 1 and v.count("[") < 1):
+                if v is None:
+                    d[k] = v
+                elif isinstance(v, str) and (v.count("{") < 1 and v.count("[") < 1):
                     d[k] = v
                 else:
                     d[k] = json.loads(v) if isinstance(v, str) else v
@@ -1502,7 +1504,7 @@ TABLES = {
                     content_vector VECTOR,
                     create_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     update_time TIMESTAMP,
-                    chunk_id VARCHAR(255) NULL,
+                    chunk_id TEXT NULL,
 	                CONSTRAINT LIGHTRAG_VDB_ENTITY_PK PRIMARY KEY (workspace, id)
                     )"""
     },
@@ -1516,7 +1518,7 @@ TABLES = {
                     content_vector VECTOR,
                     create_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     update_time TIMESTAMP,
-                    chunk_id VARCHAR(255) NULL,
+                    chunk_id TEXT NULL,
 	                CONSTRAINT LIGHTRAG_VDB_RELATION_PK PRIMARY KEY (workspace, id)
                     )"""
     },


### PR DESCRIPTION
## Description

  This PR fixes critical bugs in the PostgreSQL implementation that were causing entity extraction failures. It addresses two main issues:

  1. A type error in `_record_to_dict` where boolean values were incorrectly being processed with `.count()` method
  2. The `chunk_id` field length limitation in database schema, which was causing errors when storing concatenated chunk IDs

  ## Related Issues

  Resolves the following errors:
  - `ERROR: Failed to extract entities and relationships - 'bool' object has no attribute 'count'`
  - `ERROR: Failed to process document - value too long for type character varying(255)`

  ## Changes Made

  - Fixed type handling in `_record_to_dict` by properly checking value types before attempting to call `.count()` method:
    - Now explicitly checks if a value is `None` before further processing
    - Ensures `.count()` is only called on string values using `isinstance(v, str)`

  - Changed database schema for entity and relationship tables:
    - Modified `chunk_id` field type from `VARCHAR(255)` to `TEXT` to accommodate longer concatenated chunk IDs
    - This allows storing long lists of chunk references without truncation

  ## Checklist

  - [x] Changes tested locally
  - [ ] Code reviewed
  - [ ] Documentation updated (if necessary)
  - [ ] Unit tests added (if applicable)

  ## Additional Notes

  These changes maintain data integrity by allowing full chunk ID references to be stored without truncation, which is important for entity-document relationships in the knowledge graph.